### PR TITLE
Change color for nested strings

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -140,7 +140,6 @@ atom-text-editor .search-results .marker.current-result .region,
 .string {
   color: @orange;
 
-
   &.regexp {
     color: @cyan;
 
@@ -151,6 +150,10 @@ atom-text-editor .search-results .marker.current-result .region,
 
   &.other.link {
     color: @red;
+  }
+  
+  .string {
+    color: @green;
   }
 }
 


### PR DESCRIPTION
Some languages like JavaScript and JSPX put code inside string literals.
Therefore having a different color for nested strings would be nice.

For example in ES2015 JS:

``` js
`foo bar ${foo('bar')}`
```

Or JSPX

``` jsp
<c:if test="${foo('bar')}">
</c:if>
```
